### PR TITLE
Change receipt structure

### DIFF
--- a/_helm/sdx-survey/Chart.yaml
+++ b/_helm/sdx-survey/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.2.1
+version: 1.2.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 1.2.1
+appVersion: 1.2.2

--- a/app/receipt.py
+++ b/app/receipt.py
@@ -31,16 +31,8 @@ def make_receipt(survey_dict: dict) -> str:
 
     try:
         receipt_json = {
-            'case_id': survey_dict['case_id'],
-            'tx_id': survey_dict['tx_id'],
-            'collection': {
-                'exercise_sid':
-                    survey_dict['collection']['exercise_sid']
-            },
-            'metadata': {
-                'ru_ref': survey_dict['metadata']['ru_ref'],
-                'user_id': survey_dict['metadata']['user_id']
-            }
+            'caseId': survey_dict['case_id'],
+            'partyId': survey_dict['metadata']['user_id']
         }
     except KeyError as e:
         raise QuarantinableError(f'Failed to make receipt: {str(e)}')

--- a/tests/test_receipt.py
+++ b/tests/test_receipt.py
@@ -23,8 +23,7 @@ class TestReceipt(unittest.TestCase):
         }
 
     def test_make_receipt_valid(self):
-        expected = json.dumps({"case_id": "123", "tx_id": "tx_id", "collection": {"exercise_sid": "exercise_sid"},
-                               "metadata": {"ru_ref": "ru_ref", "user_id": "user_id"}})
+        expected = json.dumps({"caseId": "123", "partyId": "user_id"})
         self.assertEqual(make_receipt(self.test_data), expected)
 
     @mock.patch('app.receipt.publish_data')


### PR DESCRIPTION
RASRM require a slightly different struct to the receipt.