### PR TITLE
SPP filename change, use ruref instead of tx_id

### DIFF
--- a/app/transformation/transforms/spp.py
+++ b/app/transformation/transforms/spp.py
@@ -5,19 +5,19 @@ from app import get_logger
 from app.definitions.http import TransformPosterBase
 from app.definitions.transform import Transform
 from app.response import Response
-from app.transformation.formatter import get_datetime, format_date
+from app.transformation.formatter import get_datetime, format_date, split_ru_ref
 
 logger = get_logger()
 
 SPP_DATA_FORMAT: Final[str] = "%Y-%m-%dT%H-%M-%S"
 
-
 def get_name(response: Response) -> str:
     survey_id = response.get_survey_id()
+    ru_ref, _ = split_ru_ref(response.get_ru_ref())
     tx_id = response.get_tx_id()
     timestamp: datetime = get_datetime(response.get_submitted_at())
     postfix: str = format_date(timestamp, SPP_DATA_FORMAT)
-    return f"{survey_id}_SDC_{postfix}_{tx_id}.json"
+    return f"{survey_id}_SDC_{postfix}_{ru_ref}.json"
 
 
 class SPPTransform(Transform):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sdx-survey"
-version = "8.2.12"
+version = "8.2.13"
 description = "Processing EQs for SDX"
 requires-python = "==3.13.*"
 dependencies = [

--- a/tests/integration/test_spp.py
+++ b/tests/integration/test_spp.py
@@ -14,7 +14,7 @@ class TestSpp(TestBase):
 
         resp = self.client.post("/", json=self.envelope)
 
-        expected_spp_filename = "009_SDC_2023-01-18T13-33-19_bddbb412-75ea-43ce-9efa-0deb07cb8550.json"
+        expected_spp_filename = "009_SDC_2023-01-18T13-33-19_12346789012.json"
         expected_image_filename = "Sbddbb41275ea43ce_1.JPG"
         expected_index_filename = "EDC_009_20230118_bddbb41275ea43ce.csv"
         expected_receipt_filename = "REC_12346789012_A_009_202512.DAT"
@@ -59,7 +59,7 @@ class TestSpp(TestBase):
 
         resp = self.client.post("/", json=self.envelope)
 
-        expected_spp_filename = "023_SDC_2016-03-12T13-01-26_11ed69f5-6c23-40cb-b4c2-70613bfe97fc.json"
+        expected_spp_filename = "023_SDC_2016-03-12T13-01-26_12345678901.json"
         expected_image_filename = "S11ed69f56c2340cb_1.JPG"
         expected_index_filename = "EDC_023_20160312_11ed69f56c2340cb.csv"
         expected_receipt_filename = "REC_12345678901_A_023_201604.DAT"

--- a/tests/unit/transformation/transforms/test_spp.py
+++ b/tests/unit/transformation/transforms/test_spp.py
@@ -37,5 +37,5 @@ class TestSPP(unittest.TestCase):
 
     def test_get_name(self):
         actual: str = spp.get_name(Response(self.submission))
-        expected = "144_SDC_2023-09-29T09-30-21_befa5444-749f-407a-b3a2-19f1d1c7324b.json"
+        expected = "144_SDC_2023-09-29T09-30-21_12346789012.json"
         self.assertEqual(expected, actual)

--- a/uv.lock
+++ b/uv.lock
@@ -1015,7 +1015,7 @@ wheels = [
 
 [[package]]
 name = "sdx-survey"
-version = "8.2.12"
+version = "8.2.13"
 source = { virtual = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
Changes to the SPP filename following monitoring improvements